### PR TITLE
added support for vassar cds and general python data_fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ npm-debug.log
 *.iml
 # ignore generated parsers
 *.erl
+__pycache__

--- a/lib/ancile/pow_assent_providers/vassar_campus_data_service.ex
+++ b/lib/ancile/pow_assent_providers/vassar_campus_data_service.ex
@@ -3,15 +3,35 @@ defmodule Ancile.PowAssentProviders.VassarCampusDataService do
   Check Pow Assent library to see how it works.
 
   """
-  use PowAssent.Strategy.OAuth2.Base
+  use PowAssent.Strategy
+  alias Plug.Conn
+  alias PowAssent.Strategy, as: Helpers
+  alias PowAssent.{CallbackCSRFError, CallbackError, ConfigurationError, HTTPAdapter.HTTPResponse, RequestError}
+  require Logger
 
   def default_config(_config) do
     [
       site: "https://campusdataservices.cs.vassar.edu",
       authorize_url: "https://campusdataservices.cs.vassar.edu/oauth/authorize",
       token_url: "https://campusdataservices.cs.vassar.edu/oauth/token",
-      authorization_paramks: [scope: "read"]
+      authorization_params: [scope: "profile"],
     ]
+  end
+
+  @spec authorize_url(Keyword.t(), Conn.t()) :: {:ok, %{conn: Conn.t(), state: binary(), url: binary()}}
+  def authorize_url(config, conn) do
+    config = set_config(config)
+
+    state         = gen_state()
+    conn          = Conn.put_private(conn, :pow_assent_state, state)
+    redirect_uri  = config[:redirect_uri]
+    params        = authorization_params(config, state: state, redirect_uri: redirect_uri)
+    authorize_url = Keyword.get(config, :authorize_url, "/oauth/authorize")
+
+    Logger.debug(config[:site])
+    url           = Helpers.to_url(config[:site], authorize_url, params)
+
+    {:ok, %{conn: conn, url: url, state: state}}
   end
 
   def normalize(_config, user) do
@@ -27,5 +47,91 @@ defmodule Ancile.PowAssentProviders.VassarCampusDataService do
       "name" => "CDS, No data available. TODO: change it."}
 
       {:ok, user}
+  end
+
+  def callback(config, conn, params) do
+    config = set_config(config)
+    state  = conn.private[:pow_assent_state]
+
+    state
+    |> check_state(params)
+    |> get_access_token(params, config)
+    |> fetch_user(config, conn)
+  end
+
+  defp check_state(_state, %{"error" => _} = params) do
+    message   = params["error_description"] || params["error_reason"] || params["error"]
+    error     = params["error"]
+    error_uri = params["error_uri"]
+
+    {:error, %CallbackError{message: message, error: error, error_uri: error_uri}}
+  end
+
+  defp check_state(state, %{"code" => _code} = params) do
+    case params["state"] do
+      ^state -> :ok
+      _      -> {:error, %CallbackCSRFError{}}
+    end
+  end
+
+  defp get_access_token(:ok, %{"code" => code, "redirect_uri" => redirect_uri}, config) do
+    client_secret = Keyword.get(config, :client_secret)
+    client_id = Keyword.get(config, :client_id)
+    params        = authorization_params(config, code: code, client_secret: client_secret, redirect_uri: redirect_uri, grant_type: "authorization_code")
+    token_url     = Keyword.get(config, :token_url, "/oauth/token")
+
+    url = Helpers.to_url(config[:site], token_url, params)
+    headers = [{"Authorization", 
+    "Basic " <> Base.encode64(client_id <> ":" <> client_secret)}]
+
+    response = Helpers.request(:post, url, "", headers, config)
+
+    response
+    |> Helpers.decode_response(config)
+    |> process_access_token_response()
+  end
+
+  defp fetch_user({:ok, token}, config, conn) do
+    config
+    |> get_user(token)
+    |> case do
+      {:ok, user} -> {:ok, %{conn: conn, token: token, user: user}}
+      {:error, error} -> {:error, %{conn: conn, error: error}}
+    end
+  end
+  defp fetch_user({:error, error}, _config, conn),
+    do: {:error, %{conn: conn, error: error}}
+
+
+    defp authorization_params(config, params) do
+      client_id = Keyword.get(config, :client_id)
+      default   = [response_type: "code", client_id: client_id]
+      custom    = Keyword.get(config, :authorization_params, [])
+  
+      default
+      |> Keyword.merge(custom)
+      |> Keyword.merge(params)
+      |> List.keysort(0)
+    end
+
+  defp process_access_token_response({:ok, %HTTPResponse{status: 200, body: %{"access_token" => _} = token}}), do: {:ok, token}
+  defp process_access_token_response(any), do: process_response(any)
+  defp process_response({:ok, %HTTPResponse{} = response}), do: {:error, RequestError.unexpected(response)}
+  defp process_response({:error, %HTTPResponse{} = response}), do: {:error, RequestError.invalid(response)}
+  defp process_response({:error, error}), do: {:error, error}
+
+  defp gen_state do
+    24
+    |> :crypto.strong_rand_bytes()
+    |> :erlang.bitstring_to_list()
+    |> Enum.map(fn x -> :erlang.integer_to_binary(x, 16) end)
+    |> Enum.join()
+    |> String.downcase()
+  end
+
+  defp set_config(config) do
+    config
+    |> default_config()
+    |> Keyword.merge(config)
   end
 end

--- a/lib/ancile/repo_controls.ex
+++ b/lib/ancile/repo_controls.ex
@@ -191,5 +191,22 @@ defmodule Ancile.RepoControls do
     end
   end
 
+  def extract_tokens(providers) do
+    providers 
+    |> Enum.map(fn record -> {provider_name_to_site(record.provider), record.tokens["access_token"]} end)
+  end
+
+  defp provider_name_to_site(provider_name) do
+    strategy = Application.get_env(:ancile, :pow_assent)
+    |> Keyword.fetch!(:providers)
+    # |> IO.inspect
+    |> Enum.find(fn {name, _vals} -> String.to_atom(provider_name) == name end)
+    |> elem(1)
+    |> Keyword.fetch!(:strategy)
+
+    strategy.default_config(nil)
+    |> Keyword.fetch!(:site)
+    # |> IO.inspect
+  end
 
 end

--- a/lib/ancile_web/controllers/api/api_controller.ex
+++ b/lib/ancile_web/controllers/api/api_controller.ex
@@ -40,13 +40,14 @@ defmodule AncileWeb.API.RunController do
          {:ok, policies} <- Helper.get_joined_policy(app_id, user_id, purpose),
          joined_policies <- Helper.intersect_policies(policies),
          {:ok, sensitive_data} <- RepoControls.get_providers(user_id),
-         {:ok, res} <- run_python_core(joined_policies, program, nil)
+         {:ok, res} <- run_python_core(joined_policies, program, RepoControls.extract_tokens(sensitive_data))
       do
       Logger.debug("user_id: #{inspect(user_id)}")
       Logger.debug("app_id: #{inspect(app_id)}")
       Logger.debug("program: #{inspect(program)}")
       Logger.debug("policies: #{inspect(policies)}")
       Logger.debug("joined policy: #{inspect(policies)}")
+      Logger.debug("sensitive_data: #{inspect(sensitive_data |> RepoControls.extract_tokens)}")
       json(conn, %{policies: joined_policies, program: program, output: res})
 
     else

--- a/src/micro_data_core_python/functions.py
+++ b/src/micro_data_core_python/functions.py
@@ -1,5 +1,8 @@
 from src.micro_data_core_python.policy_processor import PolicyProcessor
 
+class AncileException(Exception):
+    pass
+
 
 @PolicyProcessor.decorator
 def asdf():
@@ -26,3 +29,58 @@ def get_location():
 def filter_floor(floor):
     print("FUNC: filter_floor" + str(floor))
     return True
+
+@PolicyProcessor.decorator
+def get_data(target_url, sensitive_data):
+    import requests
+    print("FUNC: GET_DATA")
+    print("  target_url: " + target_url)
+    _, access_token = _url_preprocessor(target_url, sensitive_data)
+    access_token = str(access_token, 'utf8')
+
+    r = requests.get(target_url, headers={'Authorization': "Bearer " + access_token})
+#     print(r.status_code)
+    # print(r.json())
+    try:
+        return r.json()
+    except ValueError:
+        return r.text
+
+
+def _url_preprocessor(target_url, sensitive_data):
+    """
+    A helper function that searches sensitive_data 
+    for a url that matches or is a superstring of the target url
+    it returns this record
+    """
+    import urllib.parse
+
+    def remove_prefix(instring):
+        """
+        A helper function that removes a leading www. from 
+        a given url. 
+
+        NOTE: will error if the string is exactly www.
+        This shouldn't happen but might be worth thinking
+        about, if our abstractions around data change
+        """
+        instring = instring.strip()
+        if instring == "www.":
+            raise AncileException("Invalid URL from configs")
+        elif instring.startswith("www."):
+            return instring[4:]
+        else: 
+            return instring
+
+    target_base = remove_prefix(urllib.parse.urlparse(target_url).netloc)
+    for record in sensitive_data:
+        record_base = remove_prefix(str(urllib.parse.urlparse(record[0]).netloc, 'utf8'))
+        # if record_base == target_base:
+        # Want to handle situations where site url might not
+        # be the same as api urls:
+        #  ex: github.com vs api.github.com
+        # this may or may not be a problem based on the config
+        if target_base in record_base:
+            return record
+
+    raise AncileException("No corresponding data token")


### PR DESCRIPTION
- The support for the vassar cds is ugly right now and can probably be clean up by modifying the pow library to accept some headers or have an alternate basic_auth token request flow.

- The generalized python data fetch works fine as a proof of concept, as do the associated url based record keeping functions. Whether or not they make the most sense long-term is another issue.

TODO: Add python functions that support the slack app requirements

note: Passing data into functions and out of functions in the arbitrary python code is problematic and deserves more consideration. Not addressed here.