### PR TITLE
logging and new g-cal fn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ __pycache__
 .env
 secret.yaml
 .vscode
+logs/*

--- a/app.py
+++ b/app.py
@@ -6,6 +6,10 @@ import redis
 import yaml
 import traceback
 import pickle
+import logging
+from src import logger_setup
+
+logger = logging.getLogger('primary')
 
 with open('./config/secret.yaml', 'r') as f:
     config = yaml.load(f)
@@ -51,10 +55,12 @@ def run_api():
     print(f'Policies: {policies}, Tokens: {tokens}')
     print(user_info)
 
-    res = execute(user_info=user_info, program=program, persisted_dp_uuid=persisted_dp_uuid)
+    res = execute(user_info=user_info, program=program, 
+                    persisted_dp_uuid=persisted_dp_uuid, app_id=app_id)
     print(f'Res: {res}')
     return json.dumps(res)
 
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', debug=True, use_reloader=True)
+

--- a/src/logger_setup.py
+++ b/src/logger_setup.py
@@ -1,0 +1,17 @@
+import logging
+
+primary = logging.getLogger('primary')
+primary.setLevel(logging.DEBUG)
+api_logger = logging.getLogger('api')
+api_logger.setLevel(logging.INFO)
+
+debug_file = logging.FileHandler('logs/debug.log')
+api_file = logging.FileHandler('logs/api_calls.log')
+
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+debug_file.setFormatter(formatter)
+api_file.setFormatter(formatter)
+
+primary.addHandler(debug_file)
+api_logger.addHandler(debug_file)
+api_logger.addHandler(api_file)

--- a/src/micro_data_core_python/core.py
+++ b/src/micro_data_core_python/core.py
@@ -86,7 +86,7 @@ def save_dps(users_specific):
     return iid, encrypted_data, encryption_keys
 
 
-def retrieve_dps(persisted_dp_uuid, users_specific):
+def retrieve_dps(persisted_dp_uuid, users_specific, app_id):
     print("Retrieving previously used Data Policy Pairs")
     dp_pairs = r.get(persisted_dp_uuid)
     if dp_pairs:
@@ -96,7 +96,9 @@ def retrieve_dps(persisted_dp_uuid, users_specific):
                 raise AncileException(f"active_dps don't have a user: {username}. Available names: "
                                       f"{list(active_dps.keys())}.")
             if users_specific.get(username, False) is False:
-                new_us = UserSpecific(policies=None, tokens=None, private_data=None, username=username)
+                new_us = UserSpecific(policies=None, tokens=None, 
+                                      private_data=None, username=username,
+                                      app_id=app_id)
                 users_specific[username] = new_us
             users_specific[username]._active_dps = active_dps[username]
 
@@ -106,7 +108,7 @@ def retrieve_dps(persisted_dp_uuid, users_specific):
 
 
 
-def execute(user_info, program, persisted_dp_uuid=None):
+def execute(user_info, program, persisted_dp_uuid=None, app_id=None):
     json_output = dict()
     # object to interact with the program
     result = Result()
@@ -115,12 +117,13 @@ def execute(user_info, program, persisted_dp_uuid=None):
         parsed_policies = PolicyParser.parse_policies(user.policies)
         user_specific = UserSpecific(parsed_policies, user.tokens,
                                     user.private_data,
-                                    username=user.username)
+                                    username=user.username,
+                                    app_id=app_id)
         users_specific[user.username] = user_specific
         print(user_specific._active_dps)
 
     if persisted_dp_uuid:
-        retrieve_dps(persisted_dp_uuid, users_specific)
+        retrieve_dps(persisted_dp_uuid, users_specific, app_id)
 
     glbls = safe_globals.copy()
     lcls = assemble_locals(result=result, user_specific=users_specific)

--- a/src/micro_data_core_python/datapolicypair.py
+++ b/src/micro_data_core_python/datapolicypair.py
@@ -6,7 +6,7 @@ class PrivateData(object):
 
 class DataPolicyPair:
 
-    def __init__(self, policy, token, name, username, private_data):
+    def __init__(self, policy, token, name, username, private_data, app_id=None):
         self._name = name
         self._username = username
         self._data = {'output': list()}
@@ -14,6 +14,10 @@ class DataPolicyPair:
         self._token = token
         self._private_data = private_data
         self._encryption_keys = {}
+        self._app_id = app_id
+
+    def __repr__(self):
+        return f'<DataPolicy. User: {self._username} Src: {self._name}>'
 
     def check_command_allowed(self, command):
         print(f'Checking {command} against policy: {self._policy}')

--- a/src/micro_data_core_python/decorators.py
+++ b/src/micro_data_core_python/decorators.py
@@ -1,15 +1,20 @@
 from src.micro_data_core_python.datapolicypair import DataPolicyPair
 from src.micro_data_core_python.errors import AncileException
 
+import logging
+
+logger = logging.getLogger('api')
+
 def transform_decorator(f):
     def wrapper(*args, **kwargs):
-        print(f'function: {f.__name__}. args: {args}, kwargs: {kwargs}')
+        # print(f'function: {f.__name__}. args: {args}, kwargs: {kwargs}')
         if args:
             # let's just ask to specify kwargs. Useful for policy creation.
             raise ValueError("Please specify keyword arguments instead of positions.")
         dp_pair = kwargs.get('data', False)
 
         if isinstance(dp_pair, DataPolicyPair):
+            logger.info(f'function: {f.__name__}. args: {args}, kwargs: {kwargs}, app: {dp_pair._app_id}')
             return dp_pair._call_transform(f, *args, **kwargs)
         else:
             raise ValueError("You need to provide a Data object. Use get_data to get it.")
@@ -19,13 +24,15 @@ def transform_decorator(f):
 
 def external_request_decorator(f):
     def wrapper(*args, **kwargs):
-        print(f'function: {f.__name__}. args: {args}, kwargs: {kwargs}')
+        # logger.info(f'function: {f.__name__}. args: {args}, kwargs: {kwargs}')
+        # print(f'function: {f.__name__}. args: {args}, kwargs: {kwargs}')
         if args:
             # let's just ask to specify kwargs. Useful for policy creation.
             raise ValueError("Please specify keyword arguments instead of positions.")
         dp_pair = kwargs.get('data', False)
 
         if isinstance(dp_pair, DataPolicyPair):
+            logger.info(f'function: {f.__name__}. args: {args}, kwargs: {kwargs}, app: {dp_pair._app_id}')
             return dp_pair._call_external(f, *args, **kwargs)
         else:
             raise ValueError("You need to provide a Data object. Use get_data to get it.")
@@ -35,10 +42,12 @@ def external_request_decorator(f):
 
 def use_type_decorator(f):
     def wrapper(*args, **kwargs):
-        print(f'USE function: {f.__name__}. args: {args}, kwargs: {kwargs}')
+        
+        # print(f'USE function: {f.__name__}. args: {args}, kwargs: {kwargs}')
 
         dp_pair = kwargs.get('data', False)
         if isinstance(dp_pair, DataPolicyPair):
+            logger.info(f'USE function: {f.__name__}. args: {args}, kwargs: {kwargs}, app: {dp_pair._app_id}')
             return dp_pair._use_method(f, *args, **kwargs)
         else:
             raise ValueError("You need to provide a Data object. Use get_data to get it.")
@@ -52,9 +61,13 @@ def aggregate_decorator(f):
         new_policy = None
         dp_pairs = kwargs.get('data', False)
         set_users = set()
+        app_id = None
         for dp_pair in dp_pairs:
             if not isinstance(dp_pair, DataPolicyPair):
                 raise ValueError("You need to provide a Data object. Use get_data to get it.")
+
+            app_id = dp_pair._app_id if app_id is None else app_id
+
             new_data[f'{dp_pair._username}.{dp_pair._name}'] = dp_pair._data
             set_users.add(dp_pair._username)
             if new_policy:
@@ -69,15 +82,17 @@ def aggregate_decorator(f):
 
         new_dp = DataPolicyPair(policy=new_policy, token=None, 
                                 name='Aggregate', username='Aggregate',
-                                private_data=dict())
+                                private_data=dict(), app_id=app_id)
         new_dp._data['aggregated'] = new_data
         if kwargs.get('user_specific', False):
             from src.micro_data_core_python.user_specific import UserSpecific
             user_specific_dict = kwargs['user_specific']
-            new_us = UserSpecific(policies=None, tokens=None, private_data=None, username='aggregated')
+            new_us = UserSpecific(policies=None, tokens=None, private_data=None, 
+                                  username='aggregated', app_id=app_id)
             new_us._active_dps['aggregated'] = new_dp
             user_specific_dict['aggregated'] = new_us
 
+        logger.info(f'aggregate function: {f.__name__}. args: {args}, kwargs: {kwargs}, app: {app_id}')
         new_dp._call_transform(f, *args, scope='aggregate', **kwargs)
         return new_dp
 
@@ -90,6 +105,7 @@ def reduce_aggregate_decorator(f):
         if 'value_keys' not in kwargs:
             raise AncileException(f"Missing parameter 'value_keys' for {f.__name__}")
         keys = kwargs.pop('value_keys')
+        app_id = None
 
         if isinstance(keys, str):
             keys = [keys] * len(dp_pairs)
@@ -102,6 +118,7 @@ def reduce_aggregate_decorator(f):
             if not isinstance(dp_pair, DataPolicyPair):
                 raise ValueError("You need to provide a Data object. Use get_data to get it.")
             data_list.append(dp_pair._data[key])
+            app_id = dp_pair._app_id if app_id is None else app_id
 
             if new_policy:
                 new_policy = ['intersect', dp_pair._policy, new_policy]
@@ -110,8 +127,20 @@ def reduce_aggregate_decorator(f):
 
         new_dp = DataPolicyPair(policy=new_policy, token=None,
                                 name='Aggregate', username='Aggregate',
-                                private_data=dict())
+                                private_data=dict(),
+                                app_id=app_id)
+
         new_dp._data['aggregated'] = data_list
+
+        if kwargs.get('user_specific', False):
+            from src.micro_data_core_python.user_specific import UserSpecific
+            user_specific_dict = kwargs['user_specific']
+            new_us = UserSpecific(policies=None, tokens=None, private_data=None, 
+                                  username='aggregated', app_id=app_id)
+            new_us._active_dps['aggregated'] = new_dp
+            user_specific_dict['aggregated'] = new_us
+
+        logger.info(f'r-aggregate function: {f.__name__}. args: {args}, kwargs: {kwargs}, app: {app_id}')        
 
         new_dp._call_transform(f, *args, scope='aggregate', **kwargs)
         return new_dp

--- a/src/micro_data_core_python/errors.py
+++ b/src/micro_data_core_python/errors.py
@@ -1,2 +1,6 @@
+import logging
+logger = logging.getLogger('primary')
+
 class AncileException(Exception):
-    pass
+    def __init__(self, message):
+        logger.error(message)

--- a/src/micro_data_core_python/functions/google.py
+++ b/src/micro_data_core_python/functions/google.py
@@ -56,3 +56,8 @@ def event_occuring(data, event_title=None):
     data['event_occuring'] = result
     return True
 
+@transform_decorator
+def no_events_occuring(data):
+    events = data.pop('events')
+    data['no_events_occuring'] = len(events) == 0
+    return True

--- a/src/micro_data_core_python/user_specific.py
+++ b/src/micro_data_core_python/user_specific.py
@@ -2,16 +2,19 @@ from src.micro_data_core_python.datapolicypair import DataPolicyPair
 from src.micro_data_core_python.errors import AncileException
 from src.micro_data_core_python.policy_sly import PolicyParser
 
+import logging
+logger = logging.getLogger('primary')
 
 class UserSpecific:
 
-    def __init__(self, policies, tokens, private_data, username=None):
+    def __init__(self, policies, tokens, private_data, username=None, app_id=None):
         self._username = username
         self._user_policies = policies
         self._user_tokens = tokens
         self._user_private_data = private_data
         self._active_dps = dict()
-        print(f'\nparsed policies: {self._user_policies}')
+        self._app_id = app_id
+        logger.debug(f'parsed policies for {self._username}: {self._user_policies}')
 
     def get_empty_data_pair(self, data_source, name=None):
         if data_source == 'test':
@@ -28,7 +31,8 @@ class UserSpecific:
             token = self._user_tokens[data_source]['access_token']
             dp_name = name if name else data_source
             dp_pair = DataPolicyPair(policy, token, dp_name, 
-                                    self._username, self._user_private_data)
+                                    self._username, self._user_private_data,
+                                    app_id=self._app_id)
             self._active_dps[dp_name] = dp_pair
             return dp_pair
         else:


### PR DESCRIPTION
Nothing too fancy.

Changes:
- Defined two loggers
- Added app_id to user_specific and data_policy objects. It's just for record keeping in the logging
- Added repr method to DataPolicy object that displays username and source name
- Added logging calls in the decorators. This is nice since it means that all functions we create will naturally have logging setup with them already. We could also add timing calls here if we wanted. 

Might be worth adding a toggle that replaces with null handlers at some point.