### PR TITLE
Updated intersect rule

### DIFF
--- a/ancile_core/policy.py
+++ b/ancile_core/policy.py
@@ -111,7 +111,7 @@ class Policy(object):
             if policy[0] == policy[1]:
                 return policy[0]
 
-            elif operator in ['concat', 'intersect']:
+            elif operator=='concat':
                 if policy[1] == 0:
                     return 0
                 elif policy[2] == 0:
@@ -121,10 +121,24 @@ class Policy(object):
                 elif policy[2] == 1:
                     return Policy._simplify(policy[1])
 
+            elif operator == 'intersect':
+                if policy[1] == 0:
+                    return 0
+                elif policy[2] == 0:
+                    return 0
+                elif policy[1] == 1 and policy[2][0]=='star':
+                    return 1
+                elif policy[2] == 1 and policy[1][0]=='star':
+                    return 1
+
             elif operator == 'union':
                 if policy[1] == 0:
                     return Policy._simplify(policy[2])
                 elif policy[2] == 0:
+                    return Policy._simplify(policy[1])
+                elif policy[1] == 1 and policy[2][0]=='star':
+                    return Policy._simplify(policy[2])
+                elif policy[2] == 1 and policy[1][0]=='star':
                     return Policy._simplify(policy[1])
 
             elif operator in ['intersect', 'union']:


### PR DESCRIPTION
Added rules:

1+P*=P*+1 = P*

and 

1&P*=P*&1=1

Removed 1&P reduction as it is as well can be either 0 or 1. 